### PR TITLE
Provide autofix for worker port

### DIFF
--- a/service/interpreter/activityImpl.go
+++ b/service/interpreter/activityImpl.go
@@ -62,11 +62,17 @@ func StateDecide(ctx context.Context, backendType service.BackendType, input ser
 }
 
 func getIwfWorkerBaseUrlWithFix(url string) string {
-	autofix := os.Getenv("AUTO_FIX_WORKER_URL")
-	if autofix != "" {
-		url = strings.Replace(url, "localhost", autofix, 1)
-		url = strings.Replace(url, "127.0.0.1", autofix, 1)
+	autofixUrl := os.Getenv("AUTO_FIX_WORKER_URL")
+	if autofixUrl != "" {
+		url = strings.Replace(url, "localhost", autofixUrl, 1)
+		url = strings.Replace(url, "127.0.0.1", autofixUrl, 1)
 	}
+	autofixPortEnv := os.Getenv("AUTO_FIX_WORKER_PORT_FROM_ENV")
+	if autofixPortEnv != "" {
+		envVal := os.Getenv(autofixPortEnv)
+		url = strings.Replace(url, "$"+autofixPortEnv+"$", envVal, 1)
+	}
+
 	return url
 }
 


### PR DESCRIPTION
example usage:
for worker URL: `http://localhost/:$PORT4$/iwf-samples/worker`
Then env for iWF-server: AUTO_FIX_WORKER_PORT_FROM_ENV=PORT4