### PR TITLE
fix temporal command line arguments

### DIFF
--- a/lite/start-lite-server.sh
+++ b/lite/start-lite-server.sh
@@ -17,11 +17,11 @@ echo "now trying to register iWF system search attributes..."
 
 for run in {1..60}; do
   sleep 1
-  temporal  operator search-attribute  create -name IwfWorkflowType -type Keyword
+  temporal  operator search-attribute  create --name IwfWorkflowType --type Keyword
   sleep 0.1
-  temporal  operator search-attribute  create -name IwfGlobalWorkflowVersion -type Int 
+  temporal  operator search-attribute  create --name IwfGlobalWorkflowVersion --type Int 
   sleep 0.1
-  temporal  operator search-attribute  create -name IwfExecutingStateIds -type KeywordList 
+  temporal  operator search-attribute  create --name IwfExecutingStateIds --type KeywordList 
   sleep 0.1
   if checkExists "IwfWorkflowType" ] && checkExists "IwfGlobalWorkflowVersion" && checkExists "IwfExecutingStateIds" ] ; then
       echo "All search attributes are registered"


### PR DESCRIPTION

When I  try to use the [all in one docker image](https://github.com/indeedeng/iwf?tab=readme-ov-file#using-all-in-one-docker-image) I get these errors repeatedly

It looks like the script uses one `-` where there should be 2
see https://docs.temporal.io/cli/operator#create-1

```
Error: unknown shorthand flag: 't' in -type
Usage:
  temporal operator search-attribute create [flags]

Flags:
  -h, --help               help for create
      --name stringArray   Search Attribute name.
      --type stringArray   Search Attribute type. Accepted values: Text, Keyword, Int, Double, Bool, Datetime, KeywordList.

Global Flags:
      --address string                                    Temporal server address. (default "127.0.0.1:7233")
      --api-key string                                    Sets the API key on requests.
      --codec-auth string                                 Sets the authorization header on requests to the Codec Server.
      --codec-endpoint string                             Endpoint for a remote Codec Server.
      --color string                                      Set coloring. Accepted values: always, never, auto. (default "auto")
      --env string                                        Environment to read environment-specific flags from. (default "default")
      --env-file $HOME/.config/temporalio/temporal.yaml   File to read all environments (defaults to $HOME/.config/temporalio/temporal.yaml).
      --grpc-meta stringArray                             HTTP headers to send with requests (formatted as key=value).
      --log-format string                                 Log format. Options are "text" and "json". Default is "text".
      --log-level server start-dev                        Log level. Default is "info" for most commands and "warn" for server start-dev. Accepted values: debug, info, warn, error, never. (default "info")
  -n, --namespace string                                  Temporal server namespace. (default "default")
      --no-json-shorthand-payloads                        Always show all payloads as raw payloads even if they are JSON.
  -o, --output string                                     Data output format. Note, this does not affect logging. Accepted values: text, json, jsonl, none. (default "text")
      --time-format string                                Time format. Accepted values: relative, iso, raw. (default "relative")
      --tls                                               Enable TLS encryption without additional options such as mTLS or client certificates.
      --tls-ca-data string                                Data for server CA certificate. Exclusive with -path variant.
      --tls-ca-path string                                Path to server CA certificate.
      --tls-cert-data string                              Data for x509 certificate. Exclusive with -path variant.
      --tls-cert-path string                              Path to x509 certificate.
      --tls-disable-host-verification                     Disables TLS host-name verification.
      --tls-key-data string                               Data for private certificate key. Exclusive with -path variant.
      --tls-key-path string                               Path to private certificate key.
      --tls-server-name string                            Overrides target TLS server name.

unknown shorthand flag: 't' in -type
Error: unknown shorthand flag: 't' in -type
Usage:
  temporal operator search-attribute create [flags]
```