### PR TITLE
IWF-132: Use firstRunId instead workflowId when naming WaitForStateExecutionCompletion workflow

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,15 @@ type (
 		// omitRpcInputOutputInHistory is the flag to omit rpc input/output in history
 		// the input/output is only for debugging purpose but could be too expensive to store
 		OmitRpcInputOutputInHistory *bool `yaml:"omitRpcInputOutputInHistory"`
+		// WaitForStateCompletionMigration is used to control naming of the continuedAsNew workflows
+		WaitForStateCompletionMigration WaitForStateCompletionMigration `yaml:"waitForStateCompletionMigration"`
+	}
+
+	WaitForStateCompletionMigration struct {
+		// expected values: old/both/new; defaults to 'old'
+		SignalWithStartOn string `yaml:"signalWithStartOn"`
+		// expected values: old/new; defaults to 'old'
+		WaitForOn string `yaml:"waitForOn"`
 	}
 
 	Interpreter struct {

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type (
 		// omitRpcInputOutputInHistory is the flag to omit rpc input/output in history
 		// the input/output is only for debugging purpose but could be too expensive to store
 		OmitRpcInputOutputInHistory *bool `yaml:"omitRpcInputOutputInHistory"`
-		// WaitForStateCompletionMigration is used to control naming of the continuedAsNew workflows
+		// WaitForStateCompletionMigration is used to control naming of the not continuedAsNew workflows
 		WaitForStateCompletionMigration WaitForStateCompletionMigration `yaml:"waitForStateCompletionMigration"`
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -136,3 +136,17 @@ func GetApiServiceAddressWithDefault(config Config) string {
 	}
 	return fmt.Sprintf("http://localhost:%v", config.Api.Port)
 }
+
+func GetSignalWithStartOnWithDefault(config Config) string {
+	if config.Api.WaitForStateCompletionMigration.SignalWithStartOn != "" {
+		return config.Api.WaitForStateCompletionMigration.SignalWithStartOn
+	}
+	return "old"
+}
+
+func GetWaitForOnWithDefault(config Config) string {
+	if config.Api.WaitForStateCompletionMigration.WaitForOn != "" {
+		return config.Api.WaitForStateCompletionMigration.WaitForOn
+	}
+	return "old"
+}

--- a/config/config.go
+++ b/config/config.go
@@ -130,23 +130,23 @@ func NewConfig(configPath string) (*Config, error) {
 	return config, nil
 }
 
-func GetApiServiceAddressWithDefault(config Config) string {
-	if config.Interpreter.InterpreterActivityConfig.ApiServiceAddress != "" {
-		return config.Interpreter.InterpreterActivityConfig.ApiServiceAddress
+func (c Config) GetApiServiceAddressWithDefault() string {
+	if c.Interpreter.InterpreterActivityConfig.ApiServiceAddress != "" {
+		return c.Interpreter.InterpreterActivityConfig.ApiServiceAddress
 	}
-	return fmt.Sprintf("http://localhost:%v", config.Api.Port)
+	return fmt.Sprintf("http://localhost:%v", c.Api.Port)
 }
 
-func GetSignalWithStartOnWithDefault(config Config) string {
-	if config.Api.WaitForStateCompletionMigration.SignalWithStartOn != "" {
-		return config.Api.WaitForStateCompletionMigration.SignalWithStartOn
+func (c Config) GetSignalWithStartOnWithDefault() string {
+	if c.Api.WaitForStateCompletionMigration.SignalWithStartOn != "" {
+		return c.Api.WaitForStateCompletionMigration.SignalWithStartOn
 	}
 	return "old"
 }
 
-func GetWaitForOnWithDefault(config Config) string {
-	if config.Api.WaitForStateCompletionMigration.WaitForOn != "" {
-		return config.Api.WaitForStateCompletionMigration.WaitForOn
+func (c Config) GetWaitForOnWithDefault() string {
+	if c.Api.WaitForStateCompletionMigration.WaitForOn != "" {
+		return c.Api.WaitForStateCompletionMigration.WaitForOn
 	}
 	return "old"
 }

--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -1,5 +1,8 @@
 api:
   port: 8801
+  waitForStateCompletionMigration:
+    signalWithStartOn: old
+    waitForOn: old
 interpreter:
   defaultWorkflowConfig:
     continueAsNewThreshold: 100

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -4,6 +4,9 @@ log:
   levelKey: "level"
 api:
   port: 8801
+  waitForStateCompletionMigration:
+    signalWithStartOn: old
+    waitForOn: old
 interpreter:
   temporal:
     hostPort: localhost:7233

--- a/config/development_cadence.yaml
+++ b/config/development_cadence.yaml
@@ -1,5 +1,8 @@
 api:
   port: 8801
+  waitForStateCompletionMigration:
+    signalWithStartOn: old
+    waitForOn: old
 interpreter:
   #  interpreterActivityConfig:
   #    disableSystemSearchAttributes: true # set to true if you don't have advanced visibility in Cadence, see more https://github.com/uber/cadence/issues/5085

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	google.golang.org/grpc v1.66.0 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
+	google.golang.org/protobuf v1.34.2
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.3.2 // indirect
 )

--- a/integ/config.go
+++ b/integ/config.go
@@ -13,6 +13,10 @@ func createTestConfig(testCfg IwfServiceTestConfig) config.Config {
 			Port:                9715,
 			MaxWaitSeconds:      10, // use 10 so that we can test it in the waiting test
 			OptimizedVersioning: testCfg.OptimizedVersioning,
+			WaitForStateCompletionMigration: config.WaitForStateCompletionMigration{
+				SignalWithStartOn: "old",
+				WaitForOn:         "old",
+			},
 		},
 		Interpreter: config.Interpreter{
 			VerboseDebug:              false,

--- a/service/api/cadence/client.go
+++ b/service/api/cadence/client.go
@@ -382,3 +382,7 @@ func (t *cadenceClient) ResetWorkflow(
 	}
 	return resp.GetRunId(), nil
 }
+
+func (t *cadenceClient) GetBackendType() (backendType service.BackendType) {
+	return service.BackendTypeCadence
+}

--- a/service/api/cadence/client.go
+++ b/service/api/cadence/client.go
@@ -257,6 +257,7 @@ func (t *cadenceClient) DescribeWorkflowExecution(
 
 	return &uclient.DescribeWorkflowExecutionResponse{
 		RunId:            resp.GetWorkflowExecutionInfo().GetExecution().GetRunId(),
+		FirstRunId:       "", // Cadence does not provide FirstRunId
 		Status:           status,
 		SearchAttributes: searchAttributes,
 		Memos:            memo,

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -162,7 +162,7 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 	waitForOn := env.GetSharedConfig().Api.WaitForStateCompletionMigration.WaitForOn
 
 	if waitForOn == "old" {
-		workflowId = utils.GetWorkflowIdForWaitForStateExecution(req.WorkflowId, *req.StateExecutionId, *req.WaitForKey, *req.StateId)
+		workflowId = utils.GetWorkflowIdForWaitForStateExecution(req.WorkflowId, req.StateExecutionId, req.WaitForKey, req.StateId)
 	} else { // waitForOn == "new"
 		var parentId string
 		if s.client.GetBackendType() == service.BackendTypeTemporal { // Temporal
@@ -175,7 +175,7 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 			parentId = req.WorkflowId
 		}
 
-		workflowId = utils.GetWorkflowIdForWaitForStateExecution(parentId, *req.StateExecutionId, *req.WaitForKey, *req.StateId)
+		workflowId = utils.GetWorkflowIdForWaitForStateExecution(parentId, req.StateExecutionId, req.WaitForKey, req.StateId)
 	}
 
 	options := uclient.StartWorkflowOptions{

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -158,15 +158,15 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 
 	var parentId, currentWorkflowId, _ string
 
-	response, err := s.client.DescribeWorkflowExecution(ctx, req.GetWorkflowId(), "", nil)
-	if err != nil {
-		return nil, s.handleError(err, WorkflowWaitForStateCompletionApiPath, req.WorkflowId)
-	}
+	if s.client.GetBackendType() == service.BackendTypeTemporal { // Temporal
+		response, err := s.client.DescribeWorkflowExecution(ctx, req.GetWorkflowId(), "", nil)
+		if err != nil {
+			return nil, s.handleError(err, WorkflowWaitForStateCompletionApiPath, req.WorkflowId)
 
-	if response.FirstRunId == "" {
-		parentId = req.WorkflowId // Cadence
-	} else {
-		parentId = response.FirstRunId // Temporal
+		}
+		parentId = response.FirstRunId
+	} else { // Cadence
+		parentId = req.WorkflowId
 	}
 
 	if req.WaitForKey != nil {

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -162,7 +162,7 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 	waitForOn := env.GetSharedConfig().Api.WaitForStateCompletionMigration.WaitForOn
 
 	if waitForOn == "old" {
-		workflowId = WorkflowWaitForStateId(req, req.WorkflowId)
+		workflowId = utils.GetWorkflowIdForWaitForStateExecution(req.WorkflowId, *req.StateExecutionId, *req.WaitForKey, *req.StateId)
 	} else { // waitForOn == "new"
 		var parentId string
 		if s.client.GetBackendType() == service.BackendTypeTemporal { // Temporal
@@ -175,7 +175,7 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 			parentId = req.WorkflowId
 		}
 
-		workflowId = WorkflowWaitForStateId(req, parentId)
+		workflowId = utils.GetWorkflowIdForWaitForStateExecution(parentId, *req.StateExecutionId, *req.WaitForKey, *req.StateId)
 	}
 
 	options := uclient.StartWorkflowOptions{
@@ -213,14 +213,6 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 	return &iwfidl.WorkflowWaitForStateCompletionResponse{
 		StateCompletionOutput: &output.StateCompletionOutput,
 	}, nil
-}
-
-func WorkflowWaitForStateId(req iwfidl.WorkflowWaitForStateCompletionRequest, parentId string) string {
-	if req.WaitForKey != nil {
-		return service.IwfSystemConstPrefix + parentId + "_" + *req.StateId + "_" + *req.WaitForKey
-	} else {
-		return service.IwfSystemConstPrefix + parentId + "_" + *req.StateExecutionId
-	}
 }
 
 func (s *serviceImpl) ApiV1WorkflowSignalPost(

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -159,7 +159,8 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 
 	var workflowId string
 
-	waitForOn := config.GetWaitForOnWithDefault(env.GetSharedConfig())
+	sharedConfig := env.GetSharedConfig()
+	waitForOn := sharedConfig.GetWaitForOnWithDefault()
 
 	if waitForOn == "old" {
 		workflowId = utils.GetWorkflowIdForWaitForStateExecution(req.WorkflowId, req.StateExecutionId, req.WaitForKey, req.StateId)

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -156,7 +156,7 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 ) (wresp *iwfidl.WorkflowWaitForStateCompletionResponse, retError *errors.ErrorAndStatus) {
 	defer func() { log.CapturePanic(recover(), s.logger, &retError) }()
 
-	var parentWfId, currentWorkflowId, _ string
+	var parentId, currentWorkflowId, _ string
 
 	response, err := s.client.DescribeWorkflowExecution(ctx, req.GetWorkflowId(), "", nil)
 	if err != nil {
@@ -164,17 +164,17 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 	}
 
 	if response.FirstRunId == "" {
-		parentWfId = req.WorkflowId // Cadence
+		parentId = req.WorkflowId // Cadence
 	} else {
-		parentWfId = response.FirstRunId // Temporal
+		parentId = response.FirstRunId // Temporal
 	}
 
 	if req.WaitForKey != nil {
 		currentWorkflowId = service.IwfSystemConstPrefix + req.WorkflowId + "_" + *req.StateId + "_" + *req.WaitForKey
-		_ = service.IwfSystemConstPrefix + parentWfId + "_" + *req.StateId + "_" + *req.WaitForKey
+		_ = service.IwfSystemConstPrefix + parentId + "_" + *req.StateId + "_" + *req.WaitForKey
 	} else {
-		currentWorkflowId = service.IwfSystemConstPrefix + parentWfId + "_" + *req.StateExecutionId
-		_ = service.IwfSystemConstPrefix + parentWfId + "_" + *req.StateExecutionId
+		currentWorkflowId = service.IwfSystemConstPrefix + parentId + "_" + *req.StateExecutionId
+		_ = service.IwfSystemConstPrefix + parentId + "_" + *req.StateExecutionId
 	}
 
 	options := uclient.StartWorkflowOptions{

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -159,7 +159,7 @@ func (s *serviceImpl) ApiV1WorkflowWaitForStateCompletion(
 
 	var workflowId string
 
-	waitForOn := env.GetSharedConfig().Api.WaitForStateCompletionMigration.WaitForOn
+	waitForOn := config.GetWaitForOnWithDefault(env.GetSharedConfig())
 
 	if waitForOn == "old" {
 		workflowId = utils.GetWorkflowIdForWaitForStateExecution(req.WorkflowId, req.StateExecutionId, req.WaitForKey, req.StateId)

--- a/service/api/temporal/client.go
+++ b/service/api/temporal/client.go
@@ -271,6 +271,7 @@ func (t *temporalClient) DescribeWorkflowExecution(
 
 	return &uclient.DescribeWorkflowExecutionResponse{
 		RunId:                    resp.GetWorkflowExecutionInfo().GetExecution().GetRunId(),
+		FirstRunId:               resp.GetWorkflowExecutionInfo().GetFirstRunId(),
 		Status:                   status,
 		SearchAttributes:         searchAttributes,
 		Memos:                    memo,

--- a/service/api/temporal/client.go
+++ b/service/api/temporal/client.go
@@ -442,3 +442,7 @@ func (t *temporalClient) ResetWorkflow(
 	}
 	return resp.GetRunId(), nil
 }
+
+func (t *temporalClient) GetBackendType() (backendType service.BackendType) {
+	return service.BackendTypeTemporal
+}

--- a/service/client/interfaces.go
+++ b/service/client/interfaces.go
@@ -2,6 +2,7 @@ package uclient
 
 import (
 	"context"
+	"github.com/indeedeng/iwf/service"
 	"time"
 
 	"github.com/indeedeng/iwf/gen/iwfidl"
@@ -33,6 +34,7 @@ type UnifiedClient interface {
 		ctx context.Context, valuePtr interface{}, workflowID, runID, updateType string, input interface{},
 	) error
 	ResetWorkflow(ctx context.Context, request iwfidl.WorkflowResetRequest) (runId string, err error)
+	GetBackendType() (backendType service.BackendType)
 }
 
 type errorHandler interface {

--- a/service/client/interfaces.go
+++ b/service/client/interfaces.go
@@ -71,6 +71,7 @@ type ListWorkflowExecutionsResponse struct {
 type DescribeWorkflowExecutionResponse struct {
 	Status                   iwfidl.WorkflowStatus
 	RunId                    string
+	FirstRunId               string
 	SearchAttributes         map[string]iwfidl.SearchAttribute
 	Memos                    map[string]iwfidl.EncodedObject
 	WorkflowStartedTimestamp int64

--- a/service/common/utils/utils.go
+++ b/service/common/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"github.com/indeedeng/iwf/gen/iwfidl"
+	"github.com/indeedeng/iwf/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"net/http"
 	"time"
@@ -90,4 +91,12 @@ func CheckHttpError(err error, httpResp *http.Response) bool {
 
 func ToNanoSeconds(e *timestamppb.Timestamp) int64 {
 	return e.GetSeconds()*1000*1000*1000 + int64(e.GetNanos())
+}
+
+func GetWorkflowIdForWaitForStateExecution(parentId string, stateExeId string, waitForKey string, stateId string) string {
+	if waitForKey == "" {
+		return service.IwfSystemConstPrefix + parentId + "_" + stateExeId
+	} else {
+		return service.IwfSystemConstPrefix + parentId + "_" + stateId + "_" + waitForKey
+	}
 }

--- a/service/common/utils/utils.go
+++ b/service/common/utils/utils.go
@@ -93,10 +93,10 @@ func ToNanoSeconds(e *timestamppb.Timestamp) int64 {
 	return e.GetSeconds()*1000*1000*1000 + int64(e.GetNanos())
 }
 
-func GetWorkflowIdForWaitForStateExecution(parentId string, stateExeId string, waitForKey string, stateId string) string {
-	if waitForKey == "" {
-		return service.IwfSystemConstPrefix + parentId + "_" + stateExeId
+func GetWorkflowIdForWaitForStateExecution(parentId string, stateExeId *string, waitForKey *string, stateId *string) string {
+	if waitForKey != nil && *waitForKey != "" {
+		return service.IwfSystemConstPrefix + parentId + "_" + *stateId + "_" + *waitForKey
 	} else {
-		return service.IwfSystemConstPrefix + parentId + "_" + stateId + "_" + waitForKey
+		return service.IwfSystemConstPrefix + parentId + "_" + *stateExeId
 	}
 }

--- a/service/interpreter/activityImpl.go
+++ b/service/interpreter/activityImpl.go
@@ -3,7 +3,6 @@ package interpreter
 import (
 	"context"
 	"fmt"
-	"github.com/indeedeng/iwf/config"
 	"github.com/indeedeng/iwf/gen/iwfidl"
 	"github.com/indeedeng/iwf/service"
 	"github.com/indeedeng/iwf/service/common/compatibility"
@@ -275,8 +274,9 @@ func DumpWorkflowInternal(
 	logger := provider.GetLogger(ctx)
 	logger.Info("DumpWorkflowInternal", "input", req)
 
-	apiAddress := config.GetApiServiceAddressWithDefault(env.GetSharedConfig())
 	svcCfg := env.GetSharedConfig()
+	apiAddress := svcCfg.GetApiServiceAddressWithDefault()
+
 	apiClient := iwfidl.NewAPIClient(&iwfidl.Configuration{
 		DefaultHeader: svcCfg.Interpreter.InterpreterActivityConfig.DefaultHeaders,
 		Servers: []iwfidl.ServerConfiguration{

--- a/service/interpreter/cadence/workflowProvider.go
+++ b/service/interpreter/cadence/workflowProvider.go
@@ -85,6 +85,7 @@ func (w *workflowProvider) GetWorkflowInfo(ctx interpreter.UnifiedContext) inter
 		},
 		WorkflowStartTime:        time.UnixMilli(0), // TODO need support from Cadence client: https://github.com/uber-go/cadence-client/issues/1204
 		WorkflowExecutionTimeout: time.Duration(info.ExecutionStartToCloseTimeoutSeconds) * time.Second,
+		FirstRunID:               "", // Cadence does not provide FirstRunID
 	}
 }
 

--- a/service/interpreter/interfaces.go
+++ b/service/interpreter/interfaces.go
@@ -56,6 +56,7 @@ type WorkflowInfo struct {
 	WorkflowExecution        WorkflowExecution
 	WorkflowStartTime        time.Time
 	WorkflowExecutionTimeout time.Duration
+	FirstRunID               string
 }
 
 type ActivityOptions struct {

--- a/service/interpreter/temporal/workflowProvider.go
+++ b/service/interpreter/temporal/workflowProvider.go
@@ -107,6 +107,7 @@ func (w *workflowProvider) GetWorkflowInfo(ctx interpreter.UnifiedContext) inter
 		},
 		WorkflowStartTime:        info.WorkflowStartTime,
 		WorkflowExecutionTimeout: info.WorkflowExecutionTimeout,
+		FirstRunID:               info.FirstRunID,
 	}
 }
 

--- a/service/interpreter/workflowImpl.go
+++ b/service/interpreter/workflowImpl.go
@@ -770,7 +770,7 @@ func invokeStateExecute(
 		// signalWithStart with legacy workflowId (containing parent workflowId)
 		if provider.GetBackendType() == service.BackendTypeCadence ||
 			(provider.GetBackendType() == service.BackendTypeTemporal && (signalWithStartOn == "old" || signalWithStartOn == "both")) {
-			workflowId := utils.GetWorkflowIdForWaitForStateExecution(provider.GetWorkflowInfo(ctx).FirstRunID, executionContext.StateExecutionId, state.WaitForKey, &state.StateId)
+			workflowId := utils.GetWorkflowIdForWaitForStateExecution(executionContext.WorkflowId, executionContext.StateExecutionId, state.WaitForKey, &state.StateId)
 
 			err = signalWithStart(unifiedClient, workflowId)
 			if err != nil && !unifiedClient.IsWorkflowAlreadyStartedError(err) {

--- a/service/interpreter/workflowImpl.go
+++ b/service/interpreter/workflowImpl.go
@@ -3,7 +3,6 @@ package interpreter
 import (
 	"context"
 	"fmt"
-	"github.com/indeedeng/iwf/config"
 	uclient "github.com/indeedeng/iwf/service/client"
 	"github.com/indeedeng/iwf/service/common/utils"
 	"github.com/indeedeng/iwf/service/interpreter/env"
@@ -765,7 +764,8 @@ func invokeStateExecute(
 		// this is not a problem because the signalWithStart will be very fast and highly available
 		unifiedClient := env.GetUnifiedClient()
 
-		signalWithStartOn := config.GetSignalWithStartOnWithDefault(env.GetSharedConfig())
+		sharedConfig := env.GetSharedConfig()
+		signalWithStartOn := sharedConfig.GetSignalWithStartOnWithDefault()
 
 		// signalWithStart with legacy workflowId (containing parent workflowId)
 		if provider.GetBackendType() == service.BackendTypeCadence ||

--- a/service/interpreter/workflowImpl.go
+++ b/service/interpreter/workflowImpl.go
@@ -765,29 +765,38 @@ func invokeStateExecute(
 
 		signalWithStartOn := env.GetSharedConfig().Api.WaitForStateCompletionMigration.SignalWithStartOn
 
-		if provider.GetBackendType() == service.BackendTypeTemporal {
-			if signalWithStartOn == "old" || signalWithStartOn == "both" {
-				workflowId := signalWithStartWorkflowId(state, executionContext.WorkflowId, executionContext)
-				localErr := signalWithStart(unifiedClient, workflowId)
-				if localErr != nil {
-					return failOnSignalWithStart(state, provider, err)
-				}
-			}
-			if signalWithStartOn == "both" || signalWithStartOn == "new" {
-				parentId := provider.GetWorkflowInfo(ctx).FirstRunID
-				workflowId := signalWithStartWorkflowId(state, parentId, executionContext)
-				localErr := signalWithStart(unifiedClient, workflowId)
-				if localErr != nil {
-					return failOnSignalWithStart(state, provider, err)
-				}
-			}
-		} else { // Cadence
+		// signalWithStart with legacy workflowId (containing parent workflowId)
+		if provider.GetBackendType() == service.BackendTypeCadence ||
+			(provider.GetBackendType() == service.BackendTypeTemporal && (signalWithStartOn == "old" || signalWithStartOn == "both")) {
 			workflowId := signalWithStartWorkflowId(state, executionContext.WorkflowId, executionContext)
-			localErr := signalWithStart(unifiedClient, workflowId)
-			if localErr != nil {
-				return failOnSignalWithStart(state, provider, err)
+
+			err = signalWithStart(unifiedClient, workflowId)
+			if err != nil && !unifiedClient.IsWorkflowAlreadyStartedError(err) {
+				// WorkflowAlreadyStartedError is returned when the started workflow is closed and the signal is not sent
+				// panic will let the workflow task will retry until the signal is sent
+				panic(fmt.Errorf("failed to signal on completion %w", err))
 			}
 		}
+
+		// signalWithStart with new workflowId (containing firstRunId)
+		if provider.GetBackendType() == service.BackendTypeTemporal && (signalWithStartOn == "both" || signalWithStartOn == "new") {
+			workflowId := signalWithStartWorkflowId(state, provider.GetWorkflowInfo(ctx).FirstRunID, executionContext)
+
+			// Start WaitForStateCompletionWorkflow with a new name to ensure smooth transition
+			err = signalWithStart(unifiedClient, workflowId)
+			if err != nil && !unifiedClient.IsWorkflowAlreadyStartedError(err) {
+				// WorkflowAlreadyStartedError is returned when the started workflow is closed and the signal is not sent
+				// panic will let the workflow task will retry until the signal is sent
+				panic(fmt.Errorf("failed to signal on completion %w", err))
+			}
+		}
+	}
+
+	if err != nil {
+		if shouldProceedOnExecuteApiError(state) {
+			return nil, service.ExecuteApiFailedAndProceed, nil
+		}
+		return nil, service.FailureStateExecutionStatus, convertStateApiActivityError(provider, err)
 	}
 
 	err = persistenceManager.ProcessUpsertSearchAttribute(ctx, decideResponse.GetUpsertSearchAttributes())
@@ -806,11 +815,15 @@ func invokeStateExecute(
 	return &decision, service.CompletedStateExecutionStatus, nil
 }
 
-func failOnSignalWithStart(state iwfidl.StateMovement, provider WorkflowProvider, err error) (*iwfidl.StateDecision, service.StateExecutionStatus, error) {
-	if shouldProceedOnExecuteApiError(state) {
-		return nil, service.ExecuteApiFailedAndProceed, nil
-	}
-	return nil, service.FailureStateExecutionStatus, convertStateApiActivityError(provider, err)
+func signalWithStart(unifiedClient uclient.UnifiedClient, workflowId string) error {
+	return unifiedClient.SignalWithStartWaitForStateCompletionWorkflow(
+		context.Background(),
+		uclient.StartWorkflowOptions{
+			ID:                       workflowId,
+			TaskQueue:                env.GetTaskQueue(),
+			WorkflowExecutionTimeout: 60 * time.Second, // timeout doesn't matter here as it will complete immediate with the signal
+		},
+		iwfidl.StateCompletionOutput{})
 }
 
 func signalWithStartWorkflowId(state iwfidl.StateMovement, parentId string, executionContext iwfidl.Context) string {
@@ -819,23 +832,6 @@ func signalWithStartWorkflowId(state iwfidl.StateMovement, parentId string, exec
 	} else {
 		return service.IwfSystemConstPrefix + parentId + "_" + *executionContext.StateExecutionId
 	}
-}
-
-func signalWithStart(unifiedClient uclient.UnifiedClient, workflowId string) error {
-	err := unifiedClient.SignalWithStartWaitForStateCompletionWorkflow(
-		context.Background(),
-		uclient.StartWorkflowOptions{
-			ID:                       workflowId,
-			TaskQueue:                env.GetTaskQueue(),
-			WorkflowExecutionTimeout: 60 * time.Second, // timeout doesn't matter here as it will complete immediate with the signal
-		},
-		iwfidl.StateCompletionOutput{})
-	if err != nil && !unifiedClient.IsWorkflowAlreadyStartedError(err) {
-		// WorkflowAlreadyStartedError is returned when the started workflow is closed and the signal is not sent
-		// panic will let the workflow task will retry until the signal is sent
-		panic(fmt.Errorf("failed to signal on completion %w", err))
-	}
-	return err
 }
 
 func shouldProceedOnStartApiError(state iwfidl.StateMovement) bool {

--- a/service/interpreter/workflowImpl.go
+++ b/service/interpreter/workflowImpl.go
@@ -3,6 +3,7 @@ package interpreter
 import (
 	"context"
 	"fmt"
+	"github.com/indeedeng/iwf/config"
 	uclient "github.com/indeedeng/iwf/service/client"
 	"github.com/indeedeng/iwf/service/common/utils"
 	"github.com/indeedeng/iwf/service/interpreter/env"
@@ -764,7 +765,7 @@ func invokeStateExecute(
 		// this is not a problem because the signalWithStart will be very fast and highly available
 		unifiedClient := env.GetUnifiedClient()
 
-		signalWithStartOn := env.GetSharedConfig().Api.WaitForStateCompletionMigration.SignalWithStartOn
+		signalWithStartOn := config.GetSignalWithStartOnWithDefault(env.GetSharedConfig())
 
 		// signalWithStart with legacy workflowId (containing parent workflowId)
 		if provider.GetBackendType() == service.BackendTypeCadence ||

--- a/service/interpreter/workflowImpl.go
+++ b/service/interpreter/workflowImpl.go
@@ -763,7 +763,7 @@ func invokeStateExecute(
 		// this is not a problem because the signalWithStart will be very fast and highly available
 		unifiedClient := env.GetUnifiedClient()
 
-		var parentWfId, currentWorkflowId, newWorkflowId string
+		var parentId, currentWorkflowId, newWorkflowId string
 
 		response, err := unifiedClient.DescribeWorkflowExecution(context.Background(), executionContext.WorkflowId, "", nil)
 		if err != nil {
@@ -771,17 +771,17 @@ func invokeStateExecute(
 		}
 
 		if response.FirstRunId == "" {
-			parentWfId = executionContext.WorkflowId // Cadence
+			parentId = executionContext.WorkflowId // Cadence
 		} else {
-			parentWfId = response.FirstRunId // Temporal
+			parentId = response.FirstRunId // Temporal
 		}
 
 		if state.WaitForKey != nil {
 			currentWorkflowId = service.IwfSystemConstPrefix + executionContext.WorkflowId + "_" + state.StateId + "_" + *state.WaitForKey
-			newWorkflowId = service.IwfSystemConstPrefix + parentWfId + "_" + state.StateId + "_" + *state.WaitForKey
+			newWorkflowId = service.IwfSystemConstPrefix + parentId + "_" + state.StateId + "_" + *state.WaitForKey
 		} else {
 			currentWorkflowId = service.IwfSystemConstPrefix + executionContext.WorkflowId + "_" + *executionContext.StateExecutionId
-			newWorkflowId = service.IwfSystemConstPrefix + parentWfId + "_" + *executionContext.StateExecutionId
+			newWorkflowId = service.IwfSystemConstPrefix + parentId + "_" + *executionContext.StateExecutionId
 		}
 
 		err = unifiedClient.SignalWithStartWaitForStateCompletionWorkflow(

--- a/service/interpreter/workflowImpl.go
+++ b/service/interpreter/workflowImpl.go
@@ -769,7 +769,7 @@ func invokeStateExecute(
 		// signalWithStart with legacy workflowId (containing parent workflowId)
 		if provider.GetBackendType() == service.BackendTypeCadence ||
 			(provider.GetBackendType() == service.BackendTypeTemporal && (signalWithStartOn == "old" || signalWithStartOn == "both")) {
-			workflowId := utils.GetWorkflowIdForWaitForStateExecution(provider.GetWorkflowInfo(ctx).FirstRunID, *executionContext.StateExecutionId, *state.WaitForKey, state.StateId)
+			workflowId := utils.GetWorkflowIdForWaitForStateExecution(provider.GetWorkflowInfo(ctx).FirstRunID, executionContext.StateExecutionId, state.WaitForKey, &state.StateId)
 
 			err = signalWithStart(unifiedClient, workflowId)
 			if err != nil && !unifiedClient.IsWorkflowAlreadyStartedError(err) {
@@ -781,7 +781,7 @@ func invokeStateExecute(
 
 		// signalWithStart with new workflowId (containing firstRunId)
 		if provider.GetBackendType() == service.BackendTypeTemporal && (signalWithStartOn == "both" || signalWithStartOn == "new") {
-			workflowId := utils.GetWorkflowIdForWaitForStateExecution(provider.GetWorkflowInfo(ctx).FirstRunID, *executionContext.StateExecutionId, *state.WaitForKey, state.StateId)
+			workflowId := utils.GetWorkflowIdForWaitForStateExecution(provider.GetWorkflowInfo(ctx).FirstRunID, executionContext.StateExecutionId, state.WaitForKey, &state.StateId)
 
 			// Start WaitForStateCompletionWorkflow with a new name to ensure smooth transition
 			err = signalWithStart(unifiedClient, workflowId)


### PR DESCRIPTION
### Description


### Checklist
- [x] Code compiles correctly
- [ ] Tests for the changes have been added
- [x] All tests passing
- [x] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is not backwards compatible)

### Related Issue
Closes #404
