### PR TITLE
IWF-750: Add checks for WorkflowNotReady errors for RPC overloading server

### DIFF
--- a/service/client/temporal/client.go
+++ b/service/client/temporal/client.go
@@ -82,6 +82,12 @@ func (t *temporalClient) isQueryFailedError(err error) bool {
 	return ok
 }
 
+func (t *temporalClient) isWorkflowNotReadyError(err error) bool {
+	var serviceError *serviceerror.WorkflowNotReady
+	ok := errors.As(err, &serviceError)
+	return ok
+}
+
 func (t *temporalClient) IsRequestTimeoutError(err error) bool {
 	var deadlineExceeded *serviceerror.DeadlineExceeded
 	ok := errors.As(err, &deadlineExceeded)
@@ -304,7 +310,7 @@ func (t *temporalClient) QueryWorkflow(
 		if err == nil {
 			break
 		} else {
-			if t.isQueryFailedError(err) {
+			if t.isQueryFailedError(err) || t.isWorkflowNotReadyError(err) {
 				time.Sleep(time.Duration(t.queryWorkflowFailedRetryPolicy.InitialIntervalSeconds) * time.Second)
 				attempt++
 				continue


### PR DESCRIPTION
Add checks for WorkflowNotReady errors for RPC overloading server

### Description

Draft ...

### Checklist
- [ ] Code compiles correctly
- [ ] Tests for the changes have been added
- [ ] All tests passing
- [ ] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is not backwards compatible)

### Related Issue
Closes #issue_number
