### PR TITLE
IWF-1180: add a check and substatus for IsRequestTimeoutError and LON…

### DIFF
--- a/service/api/service.go
+++ b/service/api/service.go
@@ -880,6 +880,10 @@ func (s *serviceImpl) handleError(err error, apiPath string, workflowId string) 
 		status = http.StatusBadRequest
 		subStatus = iwfidl.WORKFLOW_NOT_EXISTS_SUB_STATUS
 	}
+	if s.client.IsRequestTimeoutError(err) {
+		status = http.StatusRequestTimeout
+		subStatus = iwfidl.LONG_POLL_TIME_OUT_SUB_STATUS
+	}
 	if s.client.IsWorkflowAlreadyStartedError(err) {
 		status = http.StatusBadRequest
 		subStatus = iwfidl.WORKFLOW_ALREADY_STARTED_SUB_STATUS


### PR DESCRIPTION
…G_POLL_TIME_OUT_SUB_STATUS

### Description


### Checklist
- [ ] Code compiles correctly
- [ ] Tests for the changes have been added
- [ ] All tests passing
- [ ] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is not backwards compatible)

### Related Issue
Closes #issue_number
