### PR TITLE
IWF-1207: lockdown minio and temporal versions for the lite image

### DIFF
--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -1,18 +1,32 @@
-FROM alpine:latest AS deps
+ARG MINIO_RELEASE=RELEASE.2025-10-15T17-29-55Z
+ARG TEMPORAL_VERSION=1.7.2
+FROM --platform=$BUILDPLATFORM golang:latest AS deps
+ARG MINIO_RELEASE
+ARG TEMPORAL_VERSION
+ARG TARGETARCH
+ARG TARGETOS
 
 WORKDIR  /tmp/iwf-lite-deps
 
 #get temporal cli for each architecture we support
-ADD --checksum=sha256:e2f548af84e820b7d71f25fc6461a4e6a1ab7cdb6a80fde3c375641b0772375b --unpack=true https://github.com/temporalio/cli/releases/download/v1.7.2/temporal_cli_1.7.2_linux_amd64.tar.gz temporal/amd64/
+ADD --checksum=sha256:e2f548af84e820b7d71f25fc6461a4e6a1ab7cdb6a80fde3c375641b0772375b --unpack=true https://github.com/temporalio/cli/releases/download/v${TEMPORAL_VERSION}/temporal_cli_${TEMPORAL_VERSION}_linux_amd64.tar.gz temporal/amd64/
 
 
-ADD --checksum=sha256:0d60307cf036f5e29cf0d298dabc9dd62f1cce80f72cbfdbdb0e54ad7790a701 --unpack=true https://github.com/temporalio/cli/releases/download/v1.7.2/temporal_cli_1.7.2_linux_arm64.tar.gz temporal/arm64/
+ADD --checksum=sha256:0d60307cf036f5e29cf0d298dabc9dd62f1cce80f72cbfdbdb0e54ad7790a701 --unpack=true https://github.com/temporalio/cli/releases/download/v${TEMPORAL_VERSION}/temporal_cli_${TEMPORAL_VERSION}_linux_arm64.tar.gz temporal/arm64/
 
 # Get minio source code
 # last minio release we may want to switch to https://garagehq.deuxfleurs.fr/ or https://github.com/seaweedfs/seaweedfs
-ADD --checksum=sha256:be6d0bd3696c3a13a35f02d3a0280b64319c67918b4501c5c3d87f96d000085c --unpack=false https://github.com/minio/minio/archive/refs/tags/RELEASE.2025-10-15T17-29-55Z.tar.gz minio/archive/minio.tar.gz
+ADD --checksum=sha256:be6d0bd3696c3a13a35f02d3a0280b64319c67918b4501c5c3d87f96d000085c --unpack=true https://github.com/minio/minio/archive/refs/tags/${MINIO_RELEASE}.tar.gz minio/sourcecode
+
+
+WORKDIR /tmp/iwf-lite-deps/minio/sourcecode/minio-${MINIO_RELEASE}/
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build .
 
 FROM golang:latest
+ARG MINIO_RELEASE
 ARG TARGETARCH
 COPY . /iwf/
 WORKDIR /iwf/
@@ -27,18 +41,7 @@ COPY --from=deps /tmp/iwf-lite-deps/temporal/${TARGETARCH}/temporal /usr/local/b
 
 
 # Build and Install MinIO
-COPY --from=deps /tmp/iwf-lite-deps/minio/archive/minio.tar.gz /tmp/minio/archive/minio.tar.gz
-
-RUN mkdir -p /tmp/minio/sourcecode/minio/
-
-RUN tar -xf /tmp/minio/archive/minio.tar.gz --directory /tmp/minio/sourcecode/minio/
-
-WORKDIR /tmp/minio/sourcecode/minio/minio-RELEASE.2025-10-15T17-29-55Z/
-RUN go build /tmp/minio/sourcecode/minio/minio-RELEASE.2025-10-15T17-29-55Z/
-
-RUN cp /tmp/minio/sourcecode/minio/minio-RELEASE.2025-10-15T17-29-55Z/minio /usr/local/bin/minio
-
-WORKDIR /iwf/
+COPY --from=deps /tmp/iwf-lite-deps/minio/sourcecode/minio-${MINIO_RELEASE}/minio /usr/local/bin/minio
 
 RUN rm -rf iwf-server && \
     make bins && \

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -1,5 +1,19 @@
-FROM golang:latest
+FROM alpine:latest AS deps
 
+WORKDIR  /tmp/iwf-lite-deps
+
+#get temporal cli for each architecture we support
+ADD --checksum=sha256:e2f548af84e820b7d71f25fc6461a4e6a1ab7cdb6a80fde3c375641b0772375b --unpack=true https://github.com/temporalio/cli/releases/download/v1.7.2/temporal_cli_1.7.2_linux_amd64.tar.gz temporal/amd64/
+
+
+ADD --checksum=sha256:0d60307cf036f5e29cf0d298dabc9dd62f1cce80f72cbfdbdb0e54ad7790a701 --unpack=true https://github.com/temporalio/cli/releases/download/v1.7.2/temporal_cli_1.7.2_linux_arm64.tar.gz temporal/arm64/
+
+# Get minio source code
+# last minio release we may want to switch to https://garagehq.deuxfleurs.fr/ or https://github.com/seaweedfs/seaweedfs
+ADD --checksum=sha256:be6d0bd3696c3a13a35f02d3a0280b64319c67918b4501c5c3d87f96d000085c --unpack=false https://github.com/minio/minio/archive/refs/tags/RELEASE.2025-10-15T17-29-55Z.tar.gz minio/archive/minio.tar.gz
+
+FROM golang:latest
+ARG TARGETARCH
 COPY . /iwf/
 WORKDIR /iwf/
 
@@ -9,11 +23,22 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* 
 
-RUN curl -sSf https://temporal.download/cli.sh | sh
+COPY --from=deps /tmp/iwf-lite-deps/temporal/${TARGETARCH}/temporal /usr/local/bin/temporal
 
-# Install MinIO
-RUN curl -sSf https://dl.min.io/server/minio/release/linux-amd64/minio -o /usr/local/bin/minio && \
-    chmod +x /usr/local/bin/minio
+
+# Build and Install MinIO
+COPY --from=deps /tmp/iwf-lite-deps/minio/archive/minio.tar.gz /tmp/minio/archive/minio.tar.gz
+
+RUN mkdir -p /tmp/minio/sourcecode/minio/
+
+RUN tar -xf /tmp/minio/archive/minio.tar.gz --directory /tmp/minio/sourcecode/minio/
+
+WORKDIR /tmp/minio/sourcecode/minio/minio-RELEASE.2025-10-15T17-29-55Z/
+RUN go build /tmp/minio/sourcecode/minio/minio-RELEASE.2025-10-15T17-29-55Z/
+
+RUN cp /tmp/minio/sourcecode/minio/minio-RELEASE.2025-10-15T17-29-55Z/minio /usr/local/bin/minio
+
+WORKDIR /iwf/
 
 RUN rm -rf iwf-server && \
     make bins && \

--- a/lite/README.md
+++ b/lite/README.md
@@ -17,3 +17,4 @@ Make sure you are at the root directory of this project (parent of current):
 docker build . -t iworkflowio/iwf-server-lite:<yourTag> -f lite/Dockerfile
 ```
 
+You can use `--platform` to test building for alternate architectues see [--platform](https://docs.docker.com/reference/cli/docker/buildx/build/#platform)


### PR DESCRIPTION
### Description

running `docker pull iworkflowio/iwf-server-lite:latest && docker run -p 8801:8801 -p 7233:7233 -p 8233:8233 -e AUTO_FIX_WORKER_URL=host.docker.internal --add-host host.docker.internal:host-gateway -it iworkflowio/iwf-server-lite:latest` does not work and outputs this:

```
latest: Pulling from iworkflowio/iwf-server-lite
Digest: sha256:0c598daa504b43ad3b697156eed6ab8c488b69aa61396e286791ecc424223e73
Status: Image is up to date for iworkflowio/iwf-server-lite:latest
docker.io/iworkflowio/iwf-server-lite:latest
waiting for MinIO to start...
/usr/local/bin/minio: line 1: a: No such file or directory
temporal server started...
now trying to register iWF system search attributes...
Temporal CLI 1.7.2 (Server 1.31.1, UI 2.49.1)

Temporal Server:  0.0.0.0:7233
Temporal UI:      http://0.0.0.0:8233
Temporal Metrics: http://0.0.0.0:35607/metrics
Search attributes have been added
Search attributes have been added
Search attributes have been added
All search attributes are registered
2026/07/08 04:50:48 Loading configFile=config/development.yaml
{"level":"info","ts":"2026-07-08T04:50:48.853Z","msg":"prometheus metrics scope created","logging-call-at":"iwf.go:370"}
2026/07/08 04:50:55 failed to create bucket{{error 26 0  0x4ed6a461ad0}}

```


The issue is that `https://dl.min.io/server/minio/release/linux-amd64/minio ` now resolves to a file with this as the contents: 

```
<a href="https://github.com/minio/minio/releases/download/RELEASE.2025-09-07T16-13-09Z/minio.linux-amd64.RELEASE.2025-09-07T16-13-09Z">Found</a>.
```

We have a ticket to make our downloads to use a checksum to mitigate  supply chain issues so might as well fix this now

Long term we do want to move away from minio as I don't think its maintained any more.


### Checklist
- [ ] Code compiles correctly
- [ ] Tests for the changes have been added
- [ ] All tests passing
- [ ] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is not backwards compatible)

### Related Issue
Closes #issue_number
